### PR TITLE
[PM-15176] Require indirect dependency github.com/google/go-github/v64

### DIFF
--- a/metascoop/go.mod
+++ b/metascoop/go.mod
@@ -6,7 +6,6 @@ require gopkg.in/yaml.v3 v3.0.1
 
 require (
 	github.com/google/go-github/v64 v64.0.0
-	github.com/google/go-github/v66 v66.0.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/r3labs/diff/v3 v3.0.1
 	golang.org/x/oauth2 v0.24.0

--- a/metascoop/go.mod
+++ b/metascoop/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 require gopkg.in/yaml.v3 v3.0.1
 
 require (
-	github.com/google/go-github/v66 v66.0.0
+	github.com/google/go-github/v64 v64.0.0
 	github.com/google/go-github/v66 v66.0.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/r3labs/diff/v3 v3.0.1


### PR DESCRIPTION
## 🎟️ Tracking

PM-15176

## 📔 Objective

Require github.com/google/go-github/v64 as an indirect dependency.

Re-introducing v64 resolves silent build failures that have been occurring since updating to v66.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
