### PR TITLE
[PM-15176] Ignore ResParseError when building with fdroidserver

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -93,6 +93,11 @@ jobs:
          sudo apt-get update
          sudo apt-get install fdroidserver
 
+      - name: Ignore F-Droid ResParseError
+        run: |
+          sudo sed -i 's|raise ResParserError("res0 must be zero!")|log.warning("res0 must be zero!")|g' /usr/lib/python3/dist-packages/androguard/core/bytecodes/axml/__init__.py
+          sudo sed -i 's|raise ResParserError("res1 must be zero!")|log.warning("res1 must be zero!")|g' /usr/lib/python3/dist-packages/androguard/core/bytecodes/axml/__init__.py
+
       - name: Set up Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:


### PR DESCRIPTION
## 🎟️ Tracking

PM-15176

## 📔 Objective

This commit modifies the fdroid workflow to ignore ResParseError during the build process with fdroidserver.

The change involves patching the androguard library to replace raised ResParseError exceptions with warning logs. This addresses an issue where the build would fail due to these errors.

Original issue reported here: https://github.com/androguard/androguard/issues/1014

Solution taken from https://github.com/cesaryuan/LSPosed-Modules-F-Droid/commit/4836b9eda617741ccd7cf8833cea2dd83c7b55d6#diff-000346ffdcf71f69dce08a774e6040f30dac31c7134db990d5b5391073480774R97

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
