### PR TITLE
Stop automatically merging the pull request

### DIFF
--- a/update_repo.sh
+++ b/update_repo.sh
@@ -33,8 +33,6 @@ if [ -f "$COMMIT_MSG_FILE" ]; then
         --body "$PR_BODY")
     echo "pr_number=${PR_URL##*/}"
 
-    gh pr merge $PR_URL --squash --admin --delete-branch
-
     # Clean up the temporary commit message file
     rm "$COMMIT_MSG_FILE"
 


### PR DESCRIPTION
The script will now only create the pull request and will not merge it automatically.

## 🎟️ Tracking

Internal change

## 📔 Objective

The script will now only create the pull request and will not merge it automatically. Automatic merge is not supported due to required build checks and branch rules.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
