### PR TITLE
[PM-16853] Resolve workflow linter errors

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Generate repo from apps listing"
     runs-on: ubuntu-24.04
     env:
-      COMMIT_MSG_FILE: "${{ github.workspace }}/commit_message.tmp"
+      _COMMIT_MSG_FILE: "${{ github.workspace }}/commit_message.tmp"
 
     steps:
       - name: Checkout repo
@@ -108,7 +108,7 @@ jobs:
         env:
           GH_ACCESS_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
         run: |
-          bash run_metascoop.sh ${{ env.COMMIT_MSG_FILE }}
+          bash run_metascoop.sh ${{ env._COMMIT_MSG_FILE }}
           if [ $? -eq 0 ]; then
             echo "Changes detected"
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -134,5 +134,5 @@ jobs:
           elif [ "${{ steps.run-metascoop.outputs.has_changes }}" != "true" ]; then
             echo "No changes to save."
           else
-            bash update_repo.sh ${{ env.COMMIT_MSG_FILE }}
+            bash update_repo.sh ${{ env._COMMIT_MSG_FILE }}
           fi


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16853

## 📔 Objective

Use `_` prefix for job variables.

This fixes an error produced by workflow linter.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
