### PR TITLE
Ignore insignificant changes

### DIFF
--- a/metascoop/main.go
+++ b/metascoop/main.go
@@ -458,7 +458,7 @@ func main() {
 
 		os.Exit(1)
 	}
-	
+
 	cpath, hasSignificantChanges := apps.HasSignificantChanges(initialFdroidIndex, fdroidIndex)
 	if hasSignificantChanges {
 		log.Printf("The index %q had a significant change at JSON path %q", fdroidIndexFilePath, cpath)
@@ -468,6 +468,10 @@ func main() {
 		}
 	} else {
 		log.Printf("The index files didn't change significantly")
+		if !isCommittingNewReleases {
+		    log.Printf("No new releases detected either. Exiting with code 2.")
+		    os.Exit(2)
+		}
 	}
 	changedFiles, err := git.GetChangedFileNames(*repoDir)
 	if err != nil {

--- a/metascoop/main.go
+++ b/metascoop/main.go
@@ -459,58 +459,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	cpath, hasSignificantChanges := apps.HasSignificantChanges(initialFdroidIndex, fdroidIndex)
-	if hasSignificantChanges {
-		log.Printf("The index %q had a significant change at JSON path %q", fdroidIndexFilePath, cpath)
-		// If there were no new releases, we add a commit title indicating the index has changes.
-		if !isCommittingNewReleases {
-			commitMsg.WriteString("Automatic index update\n\n")
-		}
-	} else {
-		log.Printf("The index files didn't change significantly")
-		if !isCommittingNewReleases {
-		    log.Printf("No new releases detected either. Exiting with code 2.")
-		    os.Exit(2)
-		}
-	}
-	changedFiles, err := git.GetChangedFileNames(*repoDir)
-	if err != nil {
-		log.Fatalf("getting changed files: %s\n::endgroup::\n", err.Error())
-	}
-
-	// If only the index files changed, we ignore the commit
-	var modifiedFiles []string
-	for _, fname := range changedFiles {
-		if !strings.Contains(fname, "index") {
-			hasSignificantChanges = true
-			modifiedFiles = append(modifiedFiles, fname)
-			log.Printf("File %q is a significant change", fname)
-		}
-	}
-	if haveError {
-		os.Exit(1)
-	}
-
-	// If we don't have any significant changes, we report it with exit code 2.
-	if !hasSignificantChanges {
-		os.Exit(2)
-	}
-
-	// If there were modified files, we add them to the commit message
-	if len(modifiedFiles) > 0 {
-
-		// If there were new releases, we add a header to separate metadata changes.
-		if isCommittingNewReleases {
-			commitMsg.WriteString("## Metadata updates:\n\n")
-		}
-		commitMsg.WriteString("We performed updates to repository metadata files.\n")
-		commitMsg.WriteString("<details>\n<summary>See what changed</summary>\n\n")
-		for _, fname := range modifiedFiles {
-			commitMsg.WriteString(fmt.Sprintf("  - %s\n", fname))
-		}
-		commitMsg.WriteString("</details>\n")
-	}
-
 	if !*debugMode {
 		fmt.Println("::group::F-Droid: Reading updated metadata")
 
@@ -557,57 +505,61 @@ func main() {
 		log.Fatalf("error generating %q: %s\n", readmePath, err.Error())
 	}
 
-	// cpath, hasSignificantChanges := apps.HasSignificantChanges(initialFdroidIndex, fdroidIndex)
-	// if hasSignificantChanges {
-	// 	log.Printf("The index %q had a significant change at JSON path %q", fdroidIndexFilePath, cpath)
-	// 	// If there were no new releases, we add a commit title indicating the index has changes.
-	// 	if !isCommittingNewReleases {
-	// 		commitMsg.WriteString("Automatic index update\n\n")
-	// 	}
-	// } else {
-	// 	log.Printf("The index files didn't change significantly")
-	// }
+	cpath, hasSignificantChanges := apps.HasSignificantChanges(initialFdroidIndex, fdroidIndex)
+	if hasSignificantChanges {
+		log.Printf("The index %q had a significant change at JSON path %q", fdroidIndexFilePath, cpath)
+		// If there were no new releases, we add a commit title indicating the index has changes.
+		if !isCommittingNewReleases {
+			commitMsg.WriteString("Automatic index update\n\n")
+		}
+	} else {
+		log.Printf("The index files didn't change significantly")
+		if !isCommittingNewReleases {
+		    log.Printf("No new releases detected either. Exiting with code 2.")
+		    os.Exit(2)
+		}
+	}
 
-	// changedFiles, err := git.GetChangedFileNames(*repoDir)
-	// if err != nil {
-	// 	log.Fatalf("getting changed files: %s\n::endgroup::\n", err.Error())
-	// }
+	changedFiles, err := git.GetChangedFileNames(*repoDir)
+	if err != nil {
+		log.Fatalf("getting changed files: %s\n::endgroup::\n", err.Error())
+	}
 
-	// // If only the index files changed, we ignore the commit
-	// var modifiedFiles []string
-	// for _, fname := range changedFiles {
-	// 	if !strings.Contains(fname, "index") {
-	// 		hasSignificantChanges = true
-	// 		modifiedFiles = append(modifiedFiles, fname)
-	// 		log.Printf("File %q is a significant change", fname)
-	// 	}
-	// }
+	// If only the index files changed, we ignore the commit
+	var modifiedFiles []string
+	for _, fname := range changedFiles {
+		if !strings.Contains(fname, "index") {
+			hasSignificantChanges = true
+			modifiedFiles = append(modifiedFiles, fname)
+			log.Printf("File %q is a significant change", fname)
+		}
+	}
 
-	// // If there were modified files, we add them to the commit message
-	// if len(modifiedFiles) > 0 {
+	// If there were modified files, we add them to the commit message
+	if len(modifiedFiles) > 0 {
 
-	// 	// If there were new releases, we add a header to separate metadata changes.
-	// 	if isCommittingNewReleases {
-	// 		commitMsg.WriteString("## Metadata updates:\n\n")
-	// 	}
-	// 	commitMsg.WriteString("We performed updates to repository metadata files.\n")
-	// 	commitMsg.WriteString("<details>\n<summary>See what changed</summary>\n\n")
-	// 	for _, fname := range modifiedFiles {
-	// 		commitMsg.WriteString(fmt.Sprintf("  - %s\n", fname))
-	// 	}
-	// 	commitMsg.WriteString("</details>\n")
-	// }
+		// If there were new releases, we add a header to separate metadata changes.
+		if isCommittingNewReleases {
+			commitMsg.WriteString("## Metadata updates:\n\n")
+		}
+		commitMsg.WriteString("We performed updates to repository metadata files.\n")
+		commitMsg.WriteString("<details>\n<summary>See what changed</summary>\n\n")
+		for _, fname := range modifiedFiles {
+			commitMsg.WriteString(fmt.Sprintf("  - %s\n", fname))
+		}
+		commitMsg.WriteString("</details>\n")
+	}
 
-	// if haveError {
-	// 	os.Exit(1)
-	// }
+	if haveError {
+		os.Exit(1)
+	}
 
 	fmt.Println("::endgroup::Assessing changes")
 
-	// // If we don't have any significant changes, we report it with exit code 2.
-	// if !hasSignificantChanges {
-	// 	os.Exit(2)
-	// }
+	// If we don't have any significant changes, we report it with exit code 2.
+	if !hasSignificantChanges {
+		os.Exit(2)
+	}
 
 	// Otherwise, we write the commit message and exit with code 0.
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Ignore changes to timestamps and other insignificant metadata when checking for new releases or documentation updates. This is achieve by simply exiting early when no changes to the index file are detected and no new releases are detected.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
