### PR TITLE
[BRE-1670] Replace PAT tokens with bot token

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -45,15 +45,6 @@ jobs:
           keyvault: gh-f-droid
           secrets: "FDROID-STORE-KEYSTORE-PASSWORD"
 
-      # - name: Get Azure Key Vault secrets - BW CI
-      #   id: get-kv-secrets-ci
-      #   uses: bitwarden/gh-actions/get-keyvault-secrets@main
-      #   with:
-      #     keyvault: "bitwarden-ci"
-      #     secrets: >
-      #       github-gpg-private-key,
-      #       github-gpg-private-key-passphrase
-
       - name: Generate GH App token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
@@ -82,14 +73,6 @@ jobs:
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
-
-      # - name: Import GPG key
-      #   uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-      #   with:
-      #     gpg_private_key: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key }}
-      #     passphrase: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key-passphrase }}
-      #     git_user_signingkey: true
-      #     git_commit_gpgsign: true
 
       - name: Set up Git
         run: |

--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -1,4 +1,4 @@
-# Workflow to generate an Android app repository on F-Droidfrom the apps listing. 
+# Workflow to generate an Android app repository on F-Droid from the apps listing. 
 # This workflow is triggered by a schedule or manually via workflow_dispatch.
 
 name: Generate F-Droid app repository

--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -1,5 +1,7 @@
-name: Generate F-Droid repo
+# Workflow to generate an Android app repository on F-Droidfrom the apps listing. 
+# This workflow is triggered by a schedule or manually via workflow_dispatch.
 
+name: Generate F-Droid app repository
 
 on:
   workflow_dispatch:
@@ -12,7 +14,6 @@ on:
 
   schedule:
     - cron: "45 2 * * *"
-
 
 jobs:
   apps:
@@ -44,14 +45,14 @@ jobs:
           keyvault: gh-f-droid
           secrets: "FDROID-STORE-KEYSTORE-PASSWORD"
 
-      - name: Get Azure Key Vault secrets - BW CI
-        id: get-kv-secrets-ci
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: >
-            github-gpg-private-key,
-            github-gpg-private-key-passphrase
+      # - name: Get Azure Key Vault secrets - BW CI
+      #   id: get-kv-secrets-ci
+      #   uses: bitwarden/gh-actions/get-keyvault-secrets@main
+      #   with:
+      #     keyvault: "bitwarden-ci"
+      #     secrets: >
+      #       github-gpg-private-key,
+      #       github-gpg-private-key-passphrase
 
       - name: Generate GH App token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -82,18 +83,18 @@ jobs:
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-        with:
-          gpg_private_key: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key }}
-          passphrase: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key-passphrase }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
+      # - name: Import GPG key
+      #   uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+      #   with:
+      #     gpg_private_key: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key }}
+      #     passphrase: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key-passphrase }}
+      #     git_user_signingkey: true
+      #     git_commit_gpgsign: true
 
       - name: Set up Git
         run: |
-          git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-          git config --local user.name "bitwarden-devops-bot"
+          git config --local user.email "178206702+bw-ghapp[bot]@users.noreply.github.com"
+          git config --local user.name "bw-ghapp[bot]"
 
       - name: Configure F-Droid server
         env:

--- a/update_repo.sh
+++ b/update_repo.sh
@@ -9,46 +9,102 @@ fi
 
 COMMIT_MSG_FILE="$1"
 
-if [ -f "$COMMIT_MSG_FILE" ]; then
-    echo "Changes detected. Proceeding with git operations."
-
-    # Read the first line as the PR title
-    PR_TITLE=$(head -n 1 "$COMMIT_MSG_FILE")
-    echo "PR Title: $PR_TITLE"
-
-    # Read the remaining lines as the PR body
-    PR_BODY=$(tail -n +2 "$COMMIT_MSG_FILE")
-    echo "PR Body: $PR_BODY"
-
-    echo "Checking for existing PR from branch update_fdroid_apps..."
-    EXISTING_PR_JSON=$(gh pr list --head update_fdroid_apps --json number)
-    EXISTING_PR_NUMBER=$(echo "$EXISTING_PR_JSON" | jq -r '.[0].number // empty')
-
-    # Always push changes to update_fdroid_apps branch
-    git add .
-    git checkout -B update_fdroid_apps
-    git commit -F "$COMMIT_MSG_FILE"
-    git push -f -u origin update_fdroid_apps
-
-    if [ -n "$EXISTING_PR_NUMBER" ]; then
-        echo "Existing PR found: #$EXISTING_PR_NUMBER"
-        # Update title and body of the existing PR
-        gh pr edit "$EXISTING_PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
-        echo "PR updated."
-        echo "pr_number=$EXISTING_PR_NUMBER"
-    else
-        echo "Creating PR..."
-        PR_URL=$(gh pr create --title "$PR_TITLE" \
-            --base main \
-            --label "automated pr" \
-            --body "$PR_BODY")
-        echo "pr_number=${PR_URL##*/}"
-    fi
-
-    # Clean up the temporary commit message file
-    rm "$COMMIT_MSG_FILE"
-
-else
+if [ ! -f "$COMMIT_MSG_FILE" ]; then
     echo "Error: Commit message file does not exist or could not be found: $COMMIT_MSG_FILE" >&2
     exit 1
 fi
+
+echo "Changes detected. Proceeding with git operations."
+
+REPO="${GITHUB_REPOSITORY}"
+BRANCH="update_fdroid_apps"
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+PR_TITLE=$(head -n 1 "$COMMIT_MSG_FILE")
+PR_BODY=$(tail -n +2 "$COMMIT_MSG_FILE")
+
+echo "PR Title: $PR_TITLE"
+echo "PR Body: $PR_BODY"
+
+# Get the SHA of the base branch (main)
+echo "Getting base branch SHA..."
+BASE_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
+BASE_TREE_SHA=$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
+
+# Build tree entries from changed/added/deleted files
+echo "Building tree entries..."
+TREE_ENTRIES="[]"
+
+while IFS= read -r line; do
+    STATUS="${line:0:2}"
+    FILE="${line:3}"
+
+    if [[ "$STATUS" == " D" || "$STATUS" == "D " ]]; then
+        # Deleted file — null SHA removes it from the tree
+        TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq \
+            --arg path "$FILE" \
+            '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": null}]')
+    else
+        # Added or modified file — create a blob
+        CONTENT=$(base64 -w 0 "$FILE")
+        BLOB_SHA=$(gh api "repos/${REPO}/git/blobs" \
+            --method POST \
+            --field encoding=base64 \
+            --field content="$CONTENT" \
+            --jq '.sha')
+        TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq \
+            --arg path "$FILE" \
+            --arg sha "$BLOB_SHA" \
+            '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+    fi
+done < <(git status --porcelain)
+
+# Create new tree
+echo "Creating tree..."
+NEW_TREE_SHA=$(gh api "repos/${REPO}/git/trees" \
+    --method POST \
+    --field "base_tree=${BASE_TREE_SHA}" \
+    --field "tree=$(echo "$TREE_ENTRIES")" \
+    --jq '.sha')
+
+# Create commit
+echo "Creating commit..."
+NEW_COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
+    --method POST \
+    --field "message=${COMMIT_MSG}" \
+    --field "tree=${NEW_TREE_SHA}" \
+    --field "parents[]=${BASE_SHA}" \
+    --jq '.sha')
+
+# Force update (or create) the update_fdroid_apps branch ref
+echo "Updating branch ref..."
+if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" > /dev/null 2>&1; then
+    gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
+        --method PATCH \
+        --field sha="$NEW_COMMIT_SHA" \
+        --field force=true
+else
+    gh api "repos/${REPO}/git/refs" \
+        --method POST \
+        --field ref="refs/heads/${BRANCH}" \
+        --field sha="$NEW_COMMIT_SHA"
+fi
+
+# Create or update PR
+echo "Checking for existing PR from branch ${BRANCH}..."
+EXISTING_PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
+
+if [ -n "$EXISTING_PR_NUMBER" ]; then
+    echo "Existing PR found: #${EXISTING_PR_NUMBER}"
+    gh pr edit "$EXISTING_PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
+    echo "PR updated."
+else
+    echo "Creating PR..."
+    gh pr create --title "$PR_TITLE" \
+        --base main \
+        --head "$BRANCH" \
+        --label "automated pr" \
+        --body "$PR_BODY"
+fi
+
+# Clean up
+rm "$COMMIT_MSG_FILE"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1670](https://bitwarden.atlassian.net/browse/BRE-1670?atlOrigin=eyJpIjoiYWQ0N2Q0OGIzODE5NDU3ZDg3OWI4OGE4ZTQ0ZTRhOGEiLCJwIjoiaiJ9)

## 📔 Objective

Updating github workflows that use PAT to use app token or GITHUB_TOKEN instead.

In some cases, the PAT token was being used for simple repo actions that didn't require further authentication, such as reading from or cloning a public repository.  

GPG signing with the app token requires use of the gh API which is why there are changes to the checkout script

## ⏰ Reminders before review


- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-1670]: https://bitwarden.atlassian.net/browse/BRE-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ